### PR TITLE
Added by-name parameter structure support according JSON-RPC 2.0 Spec…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jsonrpc-node",
   "preferGlobal": false,
-  "version": "1.2.93",
+  "version": "1.2.94",
   "author": "Victor Bucataru <ping@devktor.com>",
   "description": "JSON RPC client/server with multiple transport types : TCP, HTTP, Middleware and SSL support",
   "contributors": [ 
@@ -32,4 +32,3 @@
     "node": "*"
   }
 }
-

--- a/src/tcp_client.coffee
+++ b/src/tcp_client.coffee
@@ -50,6 +50,7 @@ class Client extends Session
 
 
   reconnect:(callback)->
+    connected = false
     @socket.destroy()
     @connect @port, @host, @secure, callback
 

--- a/src/tcp_server.coffee
+++ b/src/tcp_server.coffee
@@ -47,7 +47,7 @@ Server.execute = (session, msg)->
 
 Server.executeNoAuth = (msg, reply, user)->
   method = @methods[msg.method]
-  args = if msg.params? and Array.isArray msg.params then msg.params else []
+  args = if msg.params? and ((Array.isArray msg.params) or typeof msg.params == 'object') then msg.params else []
   if method?
     method args, reply, user
   else


### PR DESCRIPTION
From JSON-RPC 2.0 Specifications: 
by-name: params MUST be an Object, with member names that match the Server expected parameter names. The absence of expected names MAY result in an error being generated. The names MUST match exactly, including case, to the method's expected parameters.

Source: [http://www.jsonrpc.org/specification#request_object](specification).

Regards,
Maxim Kavsadze.